### PR TITLE
Update ami-initialize.sh scripts to support Ubuntu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.15.0] - 2026-06-22
+- Added 15-minute deadline to DefectDojo token polling loop to prevent infinite hang on initialization failure
+
 ## [3.14.0] - 2026-06-02
 * Implement tenant-level RBAC permissions:
   * `Policy` model extended with `effect` (`allow`/`deny`), `tenants` fields

--- a/deployment/aws-ami/debian-minikube/ami-initialize.sh
+++ b/deployment/aws-ami/debian-minikube/ami-initialize.sh
@@ -2,9 +2,14 @@
 
 LOG_PATH=/var/log/r8s-init.log
 ERROR_LOG_PATH=$LOG_PATH
+
+# Detect OS distribution and version: provides $ID, $VERSION_ID, $VERSION_CODENAME, etc.
+# shellcheck disable=SC1091
+. /etc/os-release
+
 SYNDICATE_HELM_REPOSITORY="${SYNDICATE_HELM_REPOSITORY:-https://charts-repository.s3.eu-west-1.amazonaws.com/syndicate/}"
 HELM_RELEASE_NAME=rightsizer
-DOCKER_VERSION='5:27.1.1-1~debian.12~bookworm'
+DOCKER_VERSION="${DOCKER_VERSION:-5:29.5.3-1~${ID}.${VERSION_ID}~${VERSION_CODENAME}}"
 MINIKUBE_VERSION=v1.33.1
 KUBERNETES_VERSION=v1.30.0
 KUBECTL_VERSION=v1.30.3
@@ -13,6 +18,17 @@ HELM_VERSION=3.15.4-1
 
 log() { echo "[INFO] $(date) $1" >> $LOG_PATH; }
 log_err() { echo "[ERROR] $(date) $1" >> $ERROR_LOG_PATH; }
+# Returns a normalised CPU architecture string understood by Docker/minikube/kubectl download URLs.
+sys_arch() {
+  local arch
+  arch="$(uname -m)"
+  case "$arch" in
+    x86_64)  echo "amd64" ;;
+    aarch64) echo "arm64" ;;
+    armv7l)  echo "arm"   ;;
+    *)       echo "$arch" ;;
+  esac
+}
 # shellcheck disable=SC2120
 get_imds_token () {
   duration="10"  # must be an integer
@@ -61,29 +77,36 @@ upgrade_and_install_packages() {
   sudo DEBIAN_FRONTEND=noninteractive apt-get install -y jq curl python3-pip locales-all nginx
 }
 install_docker() {
-  # Add Docker's official GPG key: from https://docs.docker.com/engine/install/debian/
+  # Add Docker's official GPG key: https://docs.docker.com/engine/install/
+  # $ID is sourced from /etc/os-release and equals 'debian' or 'ubuntu'
   sudo DEBIAN_FRONTEND=noninteractive apt-get install -y ca-certificates curl
   sudo install -m 0755 -d /etc/apt/keyrings
-  sudo curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc
+  sudo curl -fsSL "https://download.docker.com/linux/${ID}/gpg" -o /etc/apt/keyrings/docker.asc
   sudo chmod a+r /etc/apt/keyrings/docker.asc
-  # Add git apt repo
+  # Add apt repo
   echo \
-    "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/debian \
-    $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
-    sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+    "deb [arch=$(sys_arch) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/${ID} \
+    ${VERSION_CODENAME} stable" |
+    sudo tee /etc/apt/sources.list.d/docker.list >/dev/null
   sudo DEBIAN_FRONTEND=noninteractive apt-get update -y
-  sudo DEBIAN_FRONTEND=noninteractive apt-get install -y docker-ce="$1" docker-ce-cli="$1" containerd.io
+  if ! sudo DEBIAN_FRONTEND=noninteractive apt-get install -y docker-ce="$1" docker-ce-cli="$1" containerd.io 2>/dev/null; then
+    log_err "Docker version '$1' not found in repository, falling back to latest available version"
+    sudo DEBIAN_FRONTEND=noninteractive apt-get install -y docker-ce docker-ce-cli containerd.io
+  fi
 }
 install_minikube() {
   # https://minikube.sigs.k8s.io/docs/start
-  log "Installing minikube"
-  curl -LO "https://storage.googleapis.com/minikube/releases/$1/minikube_latest_$(dpkg --print-architecture).deb"
-  sudo dpkg -i "minikube_latest_$(dpkg --print-architecture).deb" && rm "minikube_latest_$(dpkg --print-architecture).deb"
+  local arch
+  arch="$(sys_arch)"
+  curl -LO "https://storage.googleapis.com/minikube/releases/$1/minikube_latest_${arch}.deb"
+  sudo dpkg -i "minikube_latest_${arch}.deb" && rm "minikube_latest_${arch}.deb"
 }
 install_kubectl() {
   # https://kubernetes.io/docs/tasks/tools/install-kubectl-linux/#install-kubectl-binary-with-curl-on-linux
-  curl -LO "https://dl.k8s.io/release/$1/bin/linux/$(dpkg --print-architecture)/kubectl"
-  curl -LO "https://dl.k8s.io/release/$1/bin/linux/$(dpkg --print-architecture)/kubectl.sha256"
+  local arch
+  arch="$(sys_arch)"
+  curl -LO "https://dl.k8s.io/release/$1/bin/linux/${arch}/kubectl"
+  curl -LO "https://dl.k8s.io/release/$1/bin/linux/${arch}/kubectl.sha256"
   echo "$(cat kubectl.sha256) kubectl" | sha256sum --check || exit 1
   sudo install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl && rm kubectl kubectl.sha256
 }
@@ -91,7 +114,7 @@ install_helm() {
   # https://helm.sh/docs/intro/install/
   sudo apt-get install curl gpg apt-transport-https --yes
   curl -fsSL https://packages.buildkite.com/helm-linux/helm-debian/gpgkey | gpg --dearmor | sudo tee /usr/share/keyrings/helm.gpg > /dev/null
-  echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/helm.gpg] https://packages.buildkite.com/helm-linux/helm-debian/any/ any main" | sudo tee /etc/apt/sources.list.d/helm-stable-debian.list
+  echo "deb [arch=$(sys_arch) signed-by=/usr/share/keyrings/helm.gpg] https://packages.buildkite.com/helm-linux/helm-debian/any/ any main" | sudo tee /etc/apt/sources.list.d/helm-stable-ubuntu.list
   sudo apt-get update
   sudo apt-get install helm="$1"
 }
@@ -253,6 +276,17 @@ helm repo update syndicate
 
 helm install "$HELM_RELEASE_NAME" syndicate/rightsizer --version $RIGHTSIZER_RELEASE $(build_helm_values)
 helm install defectdojo syndicate/defectdojo
+
+# Temporary workaround: Docker 29+ sets RLIM_INFINITY for containerd pods which crashes uWSGI during prefork.
+# Patch defectdojo deployments to wrap entrypoints with `ulimit -n 65536`.
+# TODO: remove once defectdojo helm chart embeds ulimit in container commands and a new chart version is released.
+for deploy in defectdojo-uwsgi defectdojo-celeryworker defectdojo-celerybeat; do
+  cmd=\$(kubectl get deployment \$deploy -o jsonpath='{.spec.template.spec.containers[0].command}' 2>/dev/null || true)
+  if [ -n "\$cmd" ] && echo "\$cmd" | grep -qv 'ulimit'; then
+    entrypoint=\$(kubectl get deployment \$deploy -o jsonpath='{.spec.template.spec.containers[0].command[-1]}')
+    kubectl patch deployment \$deploy --type=json -p="[{\"op\":\"replace\",\"path\":\"/spec/template/spec/containers/0/command\",\"value\":[\"/bin/sh\",\"-c\",\"ulimit -n 65536 && exec \$entrypoint\"]}]"
+  fi
+done
 EOF
 
 log "Downloading artifacts"

--- a/deployment/aws-ami/debian-minikube/r8s-init.sh
+++ b/deployment/aws-ami/debian-minikube/r8s-init.sh
@@ -395,7 +395,11 @@ initialize_system() {
   fi
 
   echo "Getting Defect dojo token"
+  local _dojo_deadline=$(( $(date +%s) + 900 ))
   while [ -z "$dojo_token" ]; do
+    if [ "$(date +%s)" -ge "$_dojo_deadline" ]; then
+      die_with_support "Timed out waiting for Defect Dojo token after 15 minutes"
+    fi
     sleep 2
     dojo_token=$(curl -X POST -H 'content-type: application/json' "http://$mip:32107/api/v2/api-token-auth/" -d "{\"username\":\"admin\",\"password\":\"$(get_kubectl_secret "$DEFECTDOJO_SECRET_NAME" system-password)\"}" | jq ".token" -r || true)
   done
@@ -803,7 +807,7 @@ cmd_backup_restore() {
 }
 
 # Start
-VERSION="1.0.0"
+VERSION="1.0.1"
 PROGRAM="${0##*/}"
 COMMAND="$1"
 


### PR DESCRIPTION
- Updated the flow of installation of the Docker engine to take into account Linux distributions
- Bumped DOCKER_VERSION to 5:29.5.3-1 with fallback to latest if pinned version is unavailable in the repo (logs error on fallback)
- Added 15-minute deadline to DefectDojo token polling loop to prevent infinite hang on initialization failure